### PR TITLE
add 1283-removed to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 * Run ganache: `ganache-cli --hardfork=byzantium`
 * Run (failing) tests: `truffle test`
 
+## Demonstration of Constantinople with EIP 1283 and the reentrancy vulnerability removed
+
+### Install
+
+* Install dependencies: `npm i`
+* Install ganache@eip1283: `npm i -g ganache-cli@eip1283`
+
+### To test the reentrancy vulnerability no longer exists
+
+* Run ganache: `ganache-cli --hardfork=constantinople-1283-removed`
+* Run (failing) tests: `truffle test`
 
 ### Contact
 


### PR DESCRIPTION
Add instructions to the readme on how to run `ganache-cli`'s latest release `v6.4.0-eip1283.0`, which removes EIP 1283 and the reentrancy vulnerability exposed in Constantinople by using the new `constantinople-1283-removed` hardfork option.